### PR TITLE
Removed reference to `get_long_long`

### DIFF
--- a/problems/credit/credit.adoc
+++ b/problems/credit/credit.adoc
@@ -57,7 +57,7 @@ So, validating credit card numbers isn't hard, but it does get a bit tedious by 
 * In `credit.c` in `~/workspace/pset1/credit/`, write a program that prompts the user for a credit card number and then reports (via `printf`) whether it is a valid American Express, MasterCard, or Visa card number, per the definitions of each's format herein.
 * So that we can automate some tests of your code, we ask that your program's last line of output be `AMEX\n` or `MASTERCARD\n` or `VISA\n` or `INVALID\n`, nothing more, nothing less, and that `main` always return `0`.
 * For simplicity, you may assume that the user's input will be entirely numeric (i.e., devoid of hyphens, as might be printed on an actual card).
-* Do not assume that the user's input will fit in an `int`! Best to use `get_long_long` from CS50's library to get users' input. (Why?)
+* Do not assume that the user's input will fit in an `int`! Best to use `get_long` from CS50's library to get users' input. (Why?)
 
 
 == Hints


### PR DESCRIPTION
Removed reference to `get_long_long`  and replaces it with `get_long` which no longer exists.